### PR TITLE
Prepare for Fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.1.0
     with:
       license-check: true

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -17,4 +17,4 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-package-manager.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci-package-manager.yml@v4.1.0


### PR DESCRIPTION
For now I'm keeping the workflow versions at 4.1.0; we can update to `v4` later like we will do to others