### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "eslint": "^9.17.0"
+  }
+}


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.