### PR TITLE
chore: migrate ESLint to flat config with neostandard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,0 @@
-{
-  "extends": "standard",
-  "root": true
-}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = require('neostandard')({
+  ignores: require('neostandard').resolveIgnoresFromGitignore(),
+})


### PR DESCRIPTION
Proposal:

- Migrate ESLint from legacy `.eslintrc` to the new flat config format via `eslint.config.js`. Why ESLint v9 deprecates `.eslintrc*` files. Adopting flat config keeps the project current and enables cleaner neostandard integration.

Changes:
- Removed `.eslintrc`
- Added `eslint.config.js` with neostandard as the config base
- Ignored files are auto-resolved from `.gitignore`

